### PR TITLE
Update NPM install instructions on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You should have at least have a basic knowledge of blockchain technology and kno
 ### Installation
 
 ```
-npm install --save @pokt-network/pocket-js-web3-provider
+npm install --save @pokt-network/web3-provider
 ```
 
 ## Documentation


### PR DESCRIPTION
Got a 404 error when running: `npm install --save @pokt-network/pocket-js-web3-provider`

Changed it to:   `npm i --save @pokt-network/web3-provider`